### PR TITLE
Updated hdi container naming convention and GPT-5-Mini consistently

### DIFF
--- a/exercises/03-explore-sap-hana-cloud-vector-engine/README.md
+++ b/exercises/03-explore-sap-hana-cloud-vector-engine/README.md
@@ -73,20 +73,20 @@ The profile `hybrid` relates to the hybrid testing scenario, which allows you to
 
 For this CodeJam each of you will create their own HDI container.
 
-Use the Cloud Foundry CLI to create your HDI container **(replace the placeholder with a meaningful name like using your initials, e.g. KR-HDI)**:
+Use the Cloud Foundry CLI to create your HDI container
 
-> Hint: Replace everything between <> including the <> symbol.
+> Hint: Replace "XXX" with your initials.
 
 ```bash
-cf create-service hana hdi-shared <define-your-own-hdi-container-name>
+cf create-service hana hdi-shared cap-ai-codejam-hdi-XXX
 ```
 
 Creating the HDI container takes some time. You can monitor the process using the following command:
 
-> Hint: Replace everything between <> including the <> symbol.
+> Hint: Replace "XXX" with your initials.
 
 ```bash
-cf service <use-your-own-hdi-container-name>
+cf service cap-ai-codejam-hdi-XXX
 ```
 
 ![explore-sap-hana-cloud-vector-engine-create-hdi-instance](./assets/04-explore-sap-hana-cloud-vector-engine-create-hdi-instance.png)
@@ -105,12 +105,12 @@ You can use the CDS CLI to bind your application to the SAP HANA Schemas & HDI C
 
 👉 Open a new terminal if not already open.
 
-👉 Create a binding for your CAP application \*\*(replace the placeholder of the hdi container with the container name previously set:
+👉 Create a binding for your CAP application (replace the name of the hdi container with the container name previously set)
 
-> Hint: Replace everything between <> including the <> symbol.
+> Hint: Replace "XXX" with your initials.
 
 ```bash
-cds bind -2 <use-your-own-hdi-container-name>
+cds bind -2 cap-ai-codejam-hdi-XXX
 ```
 
 ![explore-sap-hana-cloud-vector-engine-binding-config](./assets/02-explore-sap-hana-cloud-vector-engine-binding-config.png)
@@ -146,7 +146,7 @@ The SAP HANA Cloud Vector Engine comes bundled with SAP HANA Cloud on the SAP Bu
    An HDI (HANA Deployment Infrastructure) container is a secure storage container for database artifacts like tables and views in SAP HANA Cloud. Each CAP application can use its own HDI container to store and read data from the HANA databaase. To create an HDI container, you can use the Cloud Foundry CLI.
 
    ```bash
-   cf create-service hana hdi-shared <your-hdi-container-name>
+   cf create-service hana hdi-shared cap-ai-codejam-hdi-XXX
    ```
 
    After the container is created, you can bind it to your CAP application to allow it to interact with the SAP HANA database.

--- a/exercises/04-define-db-schema/README.md
+++ b/exercises/04-define-db-schema/README.md
@@ -155,10 +155,10 @@ cds build --production
 
 > In case you forgot your HDI container name, you can simply call `cf services` to get a list of all available service instances including your HDI container.
 
-> Hint: Replace everything between <> including the <> symbol.
+> Hint: Replace "XXX" with your initials.
 
 ```bash
-cds deploy --to hana:<use-your-own-HDI-container-name > --auto-undeploy
+cds deploy --to hana:cap-ai-codejam-hdi-XXX --auto-undeploy
 ```
 
 The `--auto-undeploy` argument causes the database to adjust to the new runtime definition of your database artifacts.

--- a/exercises/07-implement-job-posting-service/README.md
+++ b/exercises/07-implement-job-posting-service/README.md
@@ -164,7 +164,7 @@ With the input validation in place, you can go ahead and implement the RAG flow.
 1. A user inputs a query describing what kind of job posting should be created.
 2. Your OData service takes the input and passes it through to the OData function handler for the RAG execution.
 3. The user query needs to be sent to an embedding client to get a vector for that user query. This is required to execute the similarity search on the already embedded vector embeddings in the SAP HANA Cloud Vector Engine. You will use the cosine similarity algorithm.
-4. A chat client establishes a connection to a specific chat model; for this Codejam, you will use the `gpt-4o-mini`.
+4. A chat client establishes a connection to a specific chat model; for this Codejam, you will use the `GPT-5-Mini`.
 5. The vector of the user query together with the textual user query, is sent to the chat model using a template giving extra context.
 6. The chat model processes the request and returns a response to your client.
 7. The response gets passed to the `DBUtils` to create a new database entry.
@@ -552,7 +552,7 @@ In this exercise, you implemented the job posting service and its OData function
 1. What is the main purpose of the `orchestrateJobPostingCreation` function in the implementation?
 
 <details><summary>Answer</summary>
-The `orchestrateJobPostingCreation` function handles the RAG flow for creating job postings. It takes a user query, creates a vector embedding for it using the `text-embedding-3-small` model, retrieves the most relevant context from the database using cosine similarity, and sends the user query along with the contextual information to a chat model (`gpt-4o-mini`). The response from the chat model is then returned and stored in the database as a new job posting.
+The `orchestrateJobPostingCreation` function handles the RAG flow for creating job postings. It takes a user query, creates a vector embedding for it using the `text-embedding-3-small` model, retrieves the most relevant context from the database using cosine similarity, and sends the user query along with the contextual information to a chat model (`gpt-5-mini`). The response from the chat model is then returned and stored in the database as a new job posting.
 </details>
 
 ## Further Reading

--- a/exercises/09-prompt-engineering-with-ai-launchpad/readme.md
+++ b/exercises/09-prompt-engineering-with-ai-launchpad/readme.md
@@ -49,7 +49,7 @@ In this exercise, you will use the SAP AI Launchpad to explore the capabilities 
 
 Under **Selected Model**, you will find the currently selected model.
 
-For this exercise, you want to change the default model `mistralai--mistral-large-instruct (2407)` to `GPT-4.1 mini`.
+For this exercise, you want to change the default model `mistralai--mistral-large-instruct (2407)` to `GPT-5-Mini`.
 
 👉 Click on the model to open the **Model Library**.
 
@@ -57,7 +57,7 @@ The **Model Library** of the SAP AI Launchpad is a catalogue of all available LL
 
 The Model Library gives you a great overview and filter options to find the correct model for your use case, be it Text, Image, Audio, or Video input. You can filter by model provider, access type, or capabilities too.
 
-👉 Select the `GPT-4.1 mini` model.
+👉 Select the `GPT-5-Mini` model.
 
 ![chat_change_model_gpt](assets/prompt-engineering-02.png)
 


### PR DESCRIPTION
Made 2 updates

1. Following a consistent naming convention prefix for hdi container name so that we could use it to delete them using a script like so:
https://gist.github.com/neelamegams/2edd87333342b6ce09cca2933fb5004e

2. Some references were there for gpt-4o-mini, gpt-4.1-mini in the later exercises and some exercises in the beginning are referring to gpt-5-mini, so made it consistent.